### PR TITLE
add GitLab

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Instant project management for GitHub repositories |
 * Bugify | $59 | http://www.bugify.com | [@bugify](https://twitter.com/bugify) | Self hosted issue management system. One-time payment. Written in PHP.
 * Post It Notes on a (Physical) Wall
 * JIRA | https://www.atlassian.com/software/jira | [@JIRA](https://twitter.com/JIRA) | $10/mo hosted - $10/yr self-hosted | JIRA is the tracker for teams planning and building great products. Thousands of teams choose JIRA to capture and organize issues, assign work, and follow team activity. At your desk or on the go with the new mobile interface, JIRA helps your team get the job done.
+* GitLab Issues | https://about.gitlab.com | [@gitlabhq](https://twitter.com/gitlabhq) | free |GitLab is open source software to collaborate on code that is used by more than 100,000 organisations worldwide. Unlimited private repositories on GitLab.com or host your own instance. Enterprise Edition includes deep LDAP support.
 
 #### Planning & Project Management
 * Sprintly | http://sprint.ly | [@sprintly](https://twitter.com/sprintly) | $49/mo- $399/mo | Don't ask how projects are going.
@@ -531,7 +532,7 @@ per successful charge. | Payments, Rebooted. | Accepting credit card payments fr
 * Codebase | https://www.codebasehq.com/
 * GitHub | https://github.com/
 * Unfuddle | https://unfuddle.com/
-
+* GitLab | https://gitlab.com
 
 #### Design Collaboration 
 * Pixelapse


### PR DESCRIPTION
This adds GitLab to the list of resources.

GitLab offers:
1) GitLab.com, unlimited private and public repositories, 100% free
2) Self-hosted GitLab, completely free
3) A paid enterprise version of GitLab, with deep LDAP support and additional features interesting for large corporations and enterprise.
