### PR TITLE
Added greenhouseci.com to continuous integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ and send personalized messages to the right users at the right time.
 
 #### Continuous Integration/Code Quality
 * Travis | https://travis-ci.org | [@travisci](https://twitter.com/travisci) | Hi I’m Travis CI, a hosted continuous integration service for open source and private projects: http://travis-ci.com  System status updates: @traviscistatus
+* Greenhouse | http://greenhouseci.com | [@greenhouseci](https://twitter.com/greenhouseci) | free - $189/mo | Hassle-free continuous integration for mobile apps | Build, test and share your iOS & Android apps for every commit. You'll be up and running with just a few clicks.
 * Circle | http://circleci.com | [@circleci](https://twitter.com/circleci) | $19/mo - $269/mo | Ship better code, faster | Easy, fast, continuous integration and deployment for web apps.
 * CodeClimate | http://codeclimate.com | [@codeclimate](http://twitter.com/codeclimate) |  | Automated  Code Review | GitHub is the largest code host on the planet with over 13.2 million repositories. Large or small, every repository comes with the same powerful tools. These tools are open to the community for public projects and secure for private projects.
 * Sempaphore | https://semaphoreapp.com | [@semaphoreapp](https://twitter.com/semaphoreapp) | $14/mo - $899/mo | Create an Amazing Workflow. | Semaphore assumes that your private or open source project is on GitHub. There are no new dependencies, hooks or SSH keys to manage. It works without any change in source code.


### PR DESCRIPTION
Great list. I added a new entry under Continuous Integration/Code Quality. No idea how they should be sorted though - currently I didn't spot any ordering logic. Maybe it should be alphabetical?
