### PR TITLE
Remove duplicate Outbrain entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -609,7 +609,6 @@ per successful charge. | Payments, Rebooted. | Accepting credit card payments fr
 * Outbrain | http://www.outbrain.com/
 * Google Adwords | http://adwords.google.com/
 * Facebook Advertising | https://www.facebook.com/advertising
-* Outbrain | http://www.outbrain.com/
 * Google Adwords | http://adwords.google.com/
 * Facebook Advertising | https://www.facebook.com/advertising
 


### PR DESCRIPTION
Outbrain was listed twice in the 'Sources of Clicks/Ad Platforms' section
