### PR TITLE
Add Source Code Snippets category and GistBox

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@
     * [Status Blogs/User Alerts](#user-content-status-blogsuser-alerts)
     * [Forms](#user-content-forms)
     * [Source Code Hosting](#user-content-source-code-hosting)
+      * [Source Code Snippets](#user-content-source-code-snippets)
     * [Design Collaboration](#user-content-design-collaboration)
     * [PaaS](#user-content-paas)
     * [VPS](#user-content-vps)
@@ -568,6 +569,11 @@ per successful charge. | Payments, Rebooted. | Accepting credit card payments fr
 * GitHub | https://github.com/
 * Unfuddle | https://unfuddle.com/
 * GitLab | https://gitlab.com
+
+##### Source Code Snippets
+* Github Gist | http://gist.github.com
+  * GistBox | http://www.gistboxapp.com/ | [@GistBox](https://twitter.com/GistBox) | The Beautiful Way to Organize Code Snippets | GistBox let's you work on code in groups and organize your code with labels 
+
 
 #### Design Collaboration
 * Pixelapse


### PR DESCRIPTION
Add Github Gist and GistBox which makes Gist manageable and useful. 
Create Source Code Snippets subcategory under Source Code Hosting.