### PR TITLE
Delete PrettyTracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -698,7 +698,6 @@ per successful charge. | Payments, Rebooted. | Accepting credit card payments fr
 
 #### SEO Tools
 * AccuRanker | https://www.accuranker.com/
-* Pretty Tracker | https://prettytracker.com/ | [@prettytracker](http://twitter.com/prettytracker) | Free - $49/mo | Beautiful, Simple Google Rank Tracking | Monitor how your website ranks in the top 300 results of Google for all of your keywords. Track the success of your SEO campaigns so you know what works. Beautiful graphs are easy to use and share. Monitor 10 keywords for free.
 * Ahrefs | https://ahrefs.com/
 * SerpBook | http://serpbook.com/
 * Serp Rank Checker | https://serprankchecker.com/ |


### PR DESCRIPTION
As show in their website:
Pretty Tracker Is Closing June 1st, 2015. Login and Export Your Data Now