### PR TITLE
Add link to fman (file manager)

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,6 +444,7 @@ for Your Enterprise | Whether planning ahead or booking on the fly, find and res
 * RescueTime | https://www.rescuetime.com | [@rescuetime](https://twitter.com/rescuetime) | $9/mo | RescueTime gives you an accurate picture of how you spend your time to help you become more productive every day.
 * Qbserve | https://qotoqot.com/qbserve/ | [@Qbserve](https://twitter.com/Qbserve) | $40 one-time | Qbserve is a time tracker for Mac that does whatever RescueTime can but also tracks project time automatically, generates invoices, and stores tracked data locally.
 * Timing | https://timingapp.com/ | [@TimingApp](https://twitter.com/TimingApp) | $29 - $79 | Automatic time and productivity tracking for Mac. Helps you stay on track with your work and ensures no billable hours get lost (if you are billing hourly).
+* fman | https://fman.io | [@m_herrmann](https://twitter.com/m_herrmann) | $14 | Manage and transfer your files with ease. For Windows, Mac and Linux.
 
 ### Prototyping/Mockups
 


### PR DESCRIPTION
[fman](https://fman.io) is a modern file manager. It brings innovative features from Sublime Text to the file manager niche. It helps users manage files, projects and uploads. It's not hosted. I'm submitting it because it's useful to Hackers (it [was on the front page](https://news.ycombinator.com/item?id=13764060) of HN) and because CONTRIBUTING.md says the tools should _ideally_ be hosted.
  