### PR TITLE
Updated to remove Stormpath and add Okta

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ Features: goals of the week, week view and quadrant matrix, pomodoro timer, shar
 
 ### User Management
 
-* Stormpath | https://stormpath.com | [@gostormpath](https://twitter.com/gostormpath) | free | Securely create, store, and manage user accounts, API keys, and user data for your web applications.
+* Okta | https://developer.okta.com/ | [@OktaDev](https://twitter.com/OktaDev) | free | Okta adds authentication, authorization, and user management to your web or mobile app within minutes.
 
 ### User Testing
 


### PR DESCRIPTION
Stormpath was merged with Okta in 2017 and is no longer supported. Okta's dev API has similar features, and I have added it to the list and removed Stormpath.