### PR TITLE
Added the Grafana Dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ Features: goals of the week, week view and quadrant matrix, pomodoro timer, shar
 * Telemetry | https://www.telemetrytv.com | [@telemetrytv](https://twitter.com/telemetrytv) | $9/mo - $749/mo | Build realtime dashboard with powerful visualizations that look beautiful on big screen TVs, desktop computers, mobile devices, and embedded systems—all using a simple REST API that works with all modern languages.
 * Dashing | http://dashing.io | Dashing is a Sinatra based framework that lets you build beautiful dashboards.
 * Klipfolio | https://www.klipfolio.com | [@klipfolio](https://twitter.com/klipfolio) | $5/user/mo - $20/user/mo | Meet Your Business Dashboard | Connect to any data service to bring your key numbers together on one dashboard. Assign your data to visualizations to show the story behind the numbers. Cultivate a data-driven culture by sharing dashboards with everyone on your team.
+* Grafana | https://grafana.com | [@grafana](https://twitter.com/grafana) | $0 - $90/mo (+9/user/mo) | The analytics platform for all your metrics | Grafana allows you to query, visualize, alert on and understand your metrics no matter where they are stored. Create, explore, and share dashboards with your team and foster a data driven culture.
 
 ### Error/Exception Handling
 


### PR DESCRIPTION
The grafana Dashboard has been featured on Hackernews multiple times, I saw it fitting to add this under the Dashboards section.