### PR TITLE
Add PageGuard to SEO Tools section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1019,6 +1019,7 @@ It's on GitHub for a reason! Please submit pull requests.
 | [Moz](https://moz.com) | [@moz](https://twitter.com/moz) | $99/mo - $599/mo | Moz provides you all the tools you need to effectively do search engine optimization. On site optimization graders, competitor tracking, backlink analysis, rank tracking and many more features available to users. |
 | [KWFinder](https://kwfinder.com/) | [@mangools_com](https://twitter.com/mangools_com) | $30+/mo | Keyword research tool |
 | [Animalz - Revive](https://revive.animalz.co/) | [@AnimalzCo](https://twitter.com/AnimalzCo) | Free | Provides a list of posts that should be refreshed. |
+| [PageGuard](https://pageguard.org) | - | Free - $79/mo | All-in-one website health scanner. Checks SEO, ADA/WCAG accessibility, performance, and best practices in one scan. Free for unlimited manual scans; paid plans add automated monitoring, alerts, and multi-site dashboard. |
 
 ## API Builder
 


### PR DESCRIPTION
## What is PageGuard?

[PageGuard](https://pageguard.org) is a free all-in-one website health scanner that checks SEO, ADA/WCAG accessibility, Core Web Vitals performance, and best practices in a single scan.

**Key features:**
- Free for unlimited manual scans
- Checks 4 dimensions: SEO, Accessibility (WCAG 2.1 AA), Performance (Core Web Vitals), Best Practices
- AI-powered analysis with actionable recommendations
- Automated monitoring dashboard (paid plans)
- Badge embed for websites

**Why it belongs in SEO Tools:**
It includes a dedicated SEO audit (meta tags, headings, canonical, Open Graph, structured data) alongside accessibility and performance checks — making it useful for anyone optimizing their site's search presence.

**Pricing:** Free (unlimited manual scans) — $9/$29/$79/mo for automated monitoring