### PR TITLE
Add Auto.dev

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -468,6 +468,7 @@ It's on GitHub for a reason! Please submit pull requests.
 | [Open Exchange Rates](https://openexchangerates.org) | - | $12/mo - $97/mo | Real-time exchange rates & currency conversion JSON API. A simple and easy-to-integrate exchange rates API in JSON format, with HTTPS and JSONP support, with examples, guides and full documentation. |
 | [FormAPI](https://formapi.io) | [@form_api](https://twitter.com/form_api) | $49/mo - $249/mo | PDF Service for Developers. Makes it easy for programmers to fill out and sign PDF documents. Saves a lot of development time if you need to generate a lot of contracts, invoices, etc. |
 | [Abstract APIs](https://www.abstractapi.com) | [@abstractapi](https://twitter.com/abstractapi) | Free - $249/mo | Suite of APIs for everyday needs (email validation, VAT calculation, IP geolocation, and more). |
+| [Auto.dev](https://auto.dev) | - | Free tier (1,000 req/mo) | Automotive data APIs for AI agents — VIN decode, vehicle listings, payments, recalls, and specs. `Hosted` |
 
 ## Site Search
 


### PR DESCRIPTION
## Add Auto.dev

[Auto.dev](https://auto.dev) provides automotive data APIs for AI agents — VIN decode, vehicle listings, payments, recalls, and specs.

- Free tier: 1,000 API requests/month
- MIT licensed
- Available as npm package (`@auto.dev/sdk`), CLI, and MCP server

Added to the **Other APIs** section.

Disclosure: I am affiliated with Auto.dev.