### PR TITLE
Add toprank to SEO Tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1023,6 +1023,7 @@ It's on GitHub for a reason! Please submit pull requests.
 | [RatedWithAI](https://ratedwithai.com) | - | Free - $29/mo | AI-powered web accessibility scanner. Checks WCAG 2.2 compliance, detects issues, and provides fix guidance. Accessibility impacts SEO — Google uses Core Web Vitals and accessibility signals in rankings. |
 | [KWFinder](https://kwfinder.com/) | [@mangools_com](https://twitter.com/mangools_com) | $30+/mo | Keyword research tool |
 | [Animalz - Revive](https://revive.animalz.co/) | [@AnimalzCo](https://twitter.com/AnimalzCo) | Free | Provides a list of posts that should be refreshed. |
+| [toprank](https://github.com/nowork-studio/toprank) | - | Free (MIT, OSS) | Open-source Claude Code plugin with 9 SEO and Google Ads skills. Connects Google Search Console, PageSpeed Insights, and the Google Ads API to audit traffic and wasted ad spend, rewrite meta tags, generate JSON-LD schema markup, and ship fixes to WordPress/Strapi/Contentful/Ghost. 107 stars, 14 forks. |
 
 ## API Builder
 


### PR DESCRIPTION
Adds **toprank** under SEO Tools.

toprank is an open-source (MIT) Claude Code plugin with 9 SEO and Google Ads skills. It gives Claude Code direct access to Google Search Console, PageSpeed Insights, and the Google Ads API — and unlike the commercial entries in this section (Ahrefs, Moz, WooRank), toprank is free, open-source, and uses an AI agent to actually ship fixes (meta tags, JSON-LD schema, keyword bids) directly to source code or CMS (WordPress/Strapi/Contentful/Ghost).

## Traction
- **107 GitHub stars, 14 forks**
- MIT licensed, actively maintained
- CHANGELOG, unit tests, and LLM-judge eval tests

- Source: https://github.com/nowork-studio/toprank